### PR TITLE
Move GLib host pin to build config

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ expat:
 freetype:
 - '2'
 glib:
-- '2'
+- '2.88'
 libxml2_devel:
 - '2.15'
 pango:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -17,7 +17,7 @@ expat:
 freetype:
 - '2'
 glib:
-- '2'
+- '2.88'
 libxml2_devel:
 - '2.15'
 pango:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -19,7 +19,7 @@ expat:
 freetype:
 - '2'
 glib:
-- '2'
+- '2.88'
 libxml2_devel:
 - '2.15'
 macos_machine:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -19,7 +19,7 @@ expat:
 freetype:
 - '2'
 glib:
-- '2'
+- '2.88'
 libxml2_devel:
 - '2.15'
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -11,7 +11,7 @@ expat:
 freetype:
 - '2'
 glib:
-- '2'
+- '2.88'
 pango:
 - '1'
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
 # AppStream dependency needs libxml2-devel 2.15
 libxml2_devel:
   - 2.15  # [unix]
+glib:
+  - 2.88

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ source:
     - 0001-remove-appstream-dependency.patch
 
 build:
-  number: 0
+  number: 1
   script:
     - if: win
       then: |
@@ -65,7 +65,7 @@ requirements:
   host:
     - freetype
     - gettext
-    - glib >=2.84.0
+    - glib
     - graphene
     - gtk4 >=4.21.1
     - fribidi


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The host section was pinning the GLib version, I moved it to the `conda_build_config`.